### PR TITLE
Issue 5: Copies parameter getting lost

### DIFF
--- a/networkclient.cpp
+++ b/networkclient.cpp
@@ -141,7 +141,7 @@ void NetworkClient::downloadPrintFileFinished(QNetworkReply *reply) {
         qDebug() << "CHROMING: " << chroming;
         QString plexing = job["plexing"].toString();
         qDebug() << "PLEXING: " << plexing;
-        QString copies = job["copies"].toString();
+        QString copies = job["copies"].toInt();
         qDebug() << "COPIES: " << copies;
 
         emit requestShowTrayMessage("Libki Print Manager", "Printing job " + jobId);


### PR DESCRIPTION
When it logs correctly, it's being cast to an Int; when it's logging as an empty string, it's been cast to String.  Changing this second logging to cast toInt to see if that helps things